### PR TITLE
refac(badges): add miab-above-below granularity

### DIFF
--- a/src/app/lib/default-data.ts
+++ b/src/app/lib/default-data.ts
@@ -821,6 +821,16 @@ const locations: Location[] = [
         cleared: false,
         miab: 1
     },
+    {
+        id: 38,
+        title: 'Mt. Hobs',
+        type: 'char',
+        zone: 0,
+        dependencies: [],
+        available: true,
+        cleared: false,
+    },
+    
 ];
 
 const characters: Character[] = [

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -439,7 +439,18 @@ const renderKeyItems = (flags: string) => {
         keyItems.push(<span key="char" className="flag-badge">Character checks</span>);
     }
     if (keyItemString.indexOf('miab') >= 0) {
-        keyItems.push(<span key="vanilla" className="flag-badge">Miab</span>);
+        const above = keyItemString.indexOf("above") >= 0;
+        const below = keyItemString.indexOf("below") >= 0;
+        const lst = keyItemString.indexOf("lst") >= 0;
+        let granularString = "";
+        if (!above && !below && !lst) {
+            granularString = "All"
+        } else {
+            if (above) granularString += "Above ";
+            if (below) granularString += "Below ";
+            if (lst) granularString += "LST ";
+        }
+        keyItems.push(<span key="vanilla" className="flag-badge">Miab:{granularString}</span>);
     }
     if (keyItemString.indexOf('unweighted') >= 0) {
         keyItems.push(<span key="unweighted" className="flag-badge">Unweighted KI distribution</span>);


### PR DESCRIPTION
- Include "above/below/lst/all" in Kmiab badges. Should work for 4.6 and 5.0. ~Should.~