### PR TITLE
Objective fix

### DIFF
--- a/src/app/lib/parse-flags.ts
+++ b/src/app/lib/parse-flags.ts
@@ -28,7 +28,7 @@ const parseFlags = (flagString: string):FlagObject => {
         // the objectives part of flag object will be a two-dimensional array that gets looped over by the objective display component
         // also "Defeat Zeromus" will no longer be a displayed objective in 5.0 given the potential for multiple win conditions
 
-        const groupTitle = ["A", "B", "C", "D", "E"]        
+        const groupTitle = ["A", "B", "C", "D", "E"];
 
         groupTitle.forEach(title => {
 
@@ -78,7 +78,7 @@ const parseFlags = (flagString: string):FlagObject => {
             for (const char of characters) {
                 if (setString.indexOf(`char_${char.toLowerCase()}`) >= 0 ) {
                     setObj.push({
-                        id: flagObj.objectives.length,
+                        id: setObj.length,
                         label: `Get ${char}`,
                         time: 0,
                     });
@@ -102,7 +102,7 @@ const parseFlags = (flagString: string):FlagObject => {
             for (const quest of quests) {
                 if (setString.indexOf(`quest_${quest.slug}`) >= 0 ) {
                     setObj.push({
-                        id: flagObj.objectives.length,
+                        id: setObj.length,
                         label: quest.title,
                         time: 0,
                     });

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -10,7 +10,7 @@ import LocationDisplay from "@/app/ui/locations/location-display";
 import TimerDisplay from "@/app/ui/timer/timer-display";
 import ObjectiveEditor from "@/app/ui/right-panel/objective-editor";
 import Info from "@/app/ui/right-panel/info";
-import { defaultKI, bosses, locations } from "../lib/default-data";
+import { defaultKI, bosses, locations } from "@/app/lib/default-data";
 import parseFlags from "../lib/parse-flags";
 import initLocations from "../lib/init-locations";
 import { FlagObject, KeyItems, Boss, Location } from "../lib/interfaces";

--- a/src/app/ui/objectives/obj-display-v5.tsx
+++ b/src/app/ui/objectives/obj-display-v5.tsx
@@ -16,6 +16,8 @@ export default function v5ObjectiveDisplay({ objectives, req, onEdit, onComplete
         return result;
     }
 
+    console.log('objectives', objectives)
+
     return (
         <div className="flex flex-col z-10 relative">
             <div className="flex justify-between">

--- a/src/app/ui/objectives/obj-display-v5.tsx
+++ b/src/app/ui/objectives/obj-display-v5.tsx
@@ -16,8 +16,6 @@ export default function v5ObjectiveDisplay({ objectives, req, onEdit, onComplete
         return result;
     }
 
-    console.log('objectives', objectives)
-
     return (
         <div className="flex flex-col z-10 relative">
             <div className="flex justify-between">


### PR DESCRIPTION
Bug fix:

v5 Objectives that were from custom quests were not given the proper id -- they read the wrong length and thus were all 0. As a result, when an objective was marked as complete, since they all had the same id, the first in order would be marked as complete and the rest filtered out from the deep clone. Should work now.