### PR TITLE
Tri state ki

### DIFF
--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -151,7 +151,7 @@ const renderBosses = (flags: string) => {
     if (bString.indexOf('whichbez') >= 0) {
         BossesText.push(<span key="whichbez" className="flag-badge"> Shadow/Golbez spells randomized</span>);
     }
-    if (bString.indexOf('whichburn') < 0 && bString.indexOf('whyburn') < 0) {
+    if (bString.indexOf('whichburn') < 0 && bString.indexOf('whyburn') < 0 && bString.indexOf('chaosburn') < 0) {
         BossesText.push(<span key="wyvern" className="flag-badge"> Standard Wyvern</span>);
     }
 

--- a/src/app/ui/ki/key-item.tsx
+++ b/src/app/ui/ki/key-item.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+import { useState } from 'react';
+import { CheckIcon } from "@heroicons/react/24/outline";
+
+export default function KeyItem({ toggleKI, color, keyName }: { toggleKI: (key: string) => void, color: boolean, keyName: string}) {
+
+    const [cleared, setCleared] = useState(false);
+
+    function handleClick() {
+        if (!color) {
+            console.log('toggling from ki component');
+            toggleKI(keyName);
+        } else if (!cleared) {
+            setCleared(true);
+        } else {
+            setCleared(false);
+            toggleKI(keyName);
+        }
+    }
+
+    function KIColor(val:boolean) {
+        return val ? "Color" : "Gray";
+    }
+
+    return (
+        <a onClick={() => handleClick()}>
+            <Image 
+                src={`/images/key-item-icons/FFIVFE-Icons-1THECrystal-${KIColor(color)}.png`}
+                alt="Crystal Crystal"
+                height={30}
+                width={30}
+            />
+            {cleared && <CheckIcon className="absolute top-2 size-10 text-yellow-400" />}
+        </a>
+    );
+
+}

--- a/src/app/ui/ki/key-item.tsx
+++ b/src/app/ui/ki/key-item.tsx
@@ -18,10 +18,6 @@ export default function KeyItem({ toggleKI, color, keyName, imgSrc, altText }: {
         }
     }
 
-    function KIColor(val:boolean) {
-        return val ? "Color" : "Gray";
-    }
-
     return (
         <a onClick={() => handleClick()} className="relative">
             <Image 

--- a/src/app/ui/ki/key-item.tsx
+++ b/src/app/ui/ki/key-item.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { CheckIcon } from "@heroicons/react/24/outline";
 
-export default function KeyItem({ toggleKI, color, keyName, imgSrc }: { toggleKI: (key: string) => void, color: boolean, keyName: string, imgSrc: string}) {
+export default function KeyItem({ toggleKI, color, keyName, imgSrc, altText }: { toggleKI: (key: string) => void, color: boolean, keyName: string, imgSrc: string, altText: string}) {
 
     const [cleared, setCleared] = useState(false);
 
@@ -23,14 +23,14 @@ export default function KeyItem({ toggleKI, color, keyName, imgSrc }: { toggleKI
     }
 
     return (
-        <a onClick={() => handleClick()}>
+        <a onClick={() => handleClick()} className="relative">
             <Image 
                 src={imgSrc}
-                alt="Crystal Crystal"
+                alt={altText}
                 height={30}
                 width={30}
             />
-            {cleared && <CheckIcon className="absolute top-2 size-10 text-yellow-400" />}
+            {cleared && <CheckIcon className="absolute top-0 size-10 text-emerald-400" />}
         </a>
     );
 

--- a/src/app/ui/ki/key-item.tsx
+++ b/src/app/ui/ki/key-item.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { CheckIcon } from "@heroicons/react/24/outline";
 
-export default function KeyItem({ toggleKI, color, keyName }: { toggleKI: (key: string) => void, color: boolean, keyName: string}) {
+export default function KeyItem({ toggleKI, color, keyName, imgSrc }: { toggleKI: (key: string) => void, color: boolean, keyName: string, imgSrc: string}) {
 
     const [cleared, setCleared] = useState(false);
 
@@ -25,7 +25,7 @@ export default function KeyItem({ toggleKI, color, keyName }: { toggleKI: (key: 
     return (
         <a onClick={() => handleClick()}>
             <Image 
-                src={`/images/key-item-icons/FFIVFE-Icons-1THECrystal-${KIColor(color)}.png`}
+                src={imgSrc}
                 alt="Crystal Crystal"
                 height={30}
                 width={30}

--- a/src/app/ui/ki/ki-display.tsx
+++ b/src/app/ui/ki/ki-display.tsx
@@ -1,24 +1,23 @@
 import Image from 'next/image';
 import { KeyItems } from "@/app/lib/interfaces";
+import KIComponent from './key-item';
 
 export default function KIDisplay({ ki, toggleKI, isV5 }: { ki: KeyItems, toggleKI: (key: string) => void, isV5: boolean }) {
     function KIColor(val:boolean) {
         return val ? "Color" : "Gray";
     }
+
     const kiObj = Object.values(ki);
     const passModifier = (ki.pass === true && !isV5) ? 1 : 0;
     const numOfKI = kiObj.filter(item => item === true).length - passModifier;
     return (
         <div className='flex flex-col items-center'>
             <div className="flex flex-wrap">
-                <a onClick={() => toggleKI('crystal')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-1THECrystal-${KIColor(ki.crystal)}.png`}
-                        alt="Crystal Crystal"
-                        height={30}
-                        width={30}
-                    />
-                </a>
+                <KIComponent
+                    keyName="crystal"
+                    toggleKI={() => toggleKI('crystal')}
+                    color={ki.crystal}
+                />
                 <a onClick={() => toggleKI('pass')}>
                     <Image 
                         src={`/images/key-item-icons/FFIVFE-Icons-2Pass-${KIColor(ki.pass)}.png`}

--- a/src/app/ui/ki/ki-display.tsx
+++ b/src/app/ui/ki/ki-display.tsx
@@ -18,144 +18,127 @@ export default function KIDisplay({ ki, toggleKI, isV5 }: { ki: KeyItems, toggle
                     toggleKI={() => toggleKI('crystal')}
                     color={ki.crystal}
                     imgSrc={`/images/key-item-icons/FFIVFE-Icons-1THECrystal-${KIColor(ki.crystal)}.png`}
+                    altText="Crystal Crystal"
                 />
-                <a onClick={() => toggleKI('pass')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-2Pass-${KIColor(ki.pass)}.png`}
-                        alt="The Pass"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('hook')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-3Hook-${KIColor(ki.hook)}.png`}
-                        alt="The Hook"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('darkness')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-4DarkCrystal-${KIColor(ki.darkness)}.png`}
-                        alt="Darkness Crystal"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('earth')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-5EarthCrystal-${KIColor(ki.earth)}.png`}
-                        alt="Earth Crystal"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('harp')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-6TwinHarp-${KIColor(ki.harp)}.png`}
-                        alt="Twin Harp"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('package')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-7Package-${KIColor(ki.package)}.png`}
-                        alt="The Package"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('sandruby')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-8SandRuby-${KIColor(ki.sandruby)}.png`}
-                        alt="Sand Ruby"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('baron')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-9BaronKey-${KIColor(ki.baron)}.png`}
-                        alt="Baron Key"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('magma')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-10MagmaKey-${KIColor(ki.magma)}.png`}
-                        alt="Magma Key"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('tower')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-11TowerKey-${KIColor(ki.tower)}.png`}
-                        alt="Tower Key"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('luca')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-12LucaKey-${KIColor(ki.luca)}.png`}
-                        alt="Luca Key"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('adamant')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-13Adamant-${KIColor(ki.adamant)}.png`}
-                        alt="Adamant"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('legend')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-14LegendSword-${KIColor(ki.legend)}.png`}
-                        alt="Legend Sword"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('pan')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-15Pan-${KIColor(ki.pan)}.png`}
-                        alt="Pan"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('spoon')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-16Spoon-${KIColor(ki.spoon)}.png`}
-                        alt="The Spoon"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('rat')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-17RatTail-${KIColor(ki.rat)}.png`}
-                        alt="Rat Tail"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                <a onClick={() => toggleKI('pink')}>
-                    <Image 
-                        src={`/images/key-item-icons/FFIVFE-Icons-18PinkTail-${KIColor(ki.pink)}.png`}
-                        alt="Pink Tail"
-                        height={30}
-                        width={30}
-                    />
-                </a>
-                
+                <KIComponent
+                    keyName="pass"
+                    toggleKI={() => toggleKI('pass')}
+                    color={ki.pass}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-2Pass-${KIColor(ki.pass)}.png`}
+                    altText="The Pass"
+                />
+                <KIComponent
+                    keyName="hook"
+                    toggleKI={() => toggleKI('hook')}
+                    color={ki.hook}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-3Hook-${KIColor(ki.hook)}.png`}
+                    altText="The Hook"
+                />
+                <KIComponent
+                    keyName="darkness"
+                    toggleKI={() => toggleKI('darkness')}
+                    color={ki.darkness}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-4DarkCrystal-${KIColor(ki.darkness)}.png`}
+                    altText="The Darkness"
+                />
+               <KIComponent
+                    keyName="earth"
+                    toggleKI={() => toggleKI('earth')}
+                    color={ki.earth}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-5EarthCrystal-${KIColor(ki.earth)}.png`}
+                    altText="Earth Crystal"
+                />
+                <KIComponent
+                    keyName="twinharp"
+                    toggleKI={() => toggleKI('harp')}
+                    color={ki.harp}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-6TwinHarp-${KIColor(ki.harp)}.png`}
+                    altText="Twin Harp"
+                />
+                <KIComponent
+                    keyName="package"
+                    toggleKI={() => toggleKI('package')}
+                    color={ki.package}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-7Package-${KIColor(ki.package)}.png`}
+                    altText="Package"
+                />
+                <KIComponent
+                    keyName="sandruby"
+                    toggleKI={() => toggleKI('sandruby')}
+                    color={ki.sandruby}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-8SandRuby-${KIColor(ki.sandruby)}.png`}
+                    altText="Sand Ruby"
+                />
+                <KIComponent
+                    keyName="baron"
+                    toggleKI={() => toggleKI('baron')}
+                    color={ki.baron}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-9BaronKey-${KIColor(ki.baron)}.png`}
+                    altText="Baron Key"
+                />
+                <KIComponent
+                    keyName="magma"
+                    toggleKI={() => toggleKI('magma')}
+                    color={ki.magma}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-10MagmaKey-${KIColor(ki.magma)}.png`}
+                    altText="Magma Key"
+                />
+                <KIComponent
+                    keyName="tower"
+                    toggleKI={() => toggleKI('tower')}
+                    color={ki.tower}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-11TowerKey-${KIColor(ki.tower)}.png`}
+                    altText="Tower Key"
+                />
+                <KIComponent
+                    keyName="luca"
+                    toggleKI={() => toggleKI('luca')}
+                    color={ki.luca}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-12LucaKey-${KIColor(ki.luca)}.png`}
+                    altText="Luca Key"
+                />
+                <KIComponent
+                    keyName="adamant"
+                    toggleKI={() => toggleKI('adamant')}
+                    color={ki.adamant}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-13Adamant-${KIColor(ki.adamant)}.png`}
+                    altText="Adamant"
+                />
+                <KIComponent
+                    keyName="legend"
+                    toggleKI={() => toggleKI('legend')}
+                    color={ki.legend}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-14LegendSword-${KIColor(ki.legend)}.png`}
+                    altText="Legend Sword"
+                />
+                <KIComponent
+                    keyName="pan"
+                    toggleKI={() => toggleKI('pan')}
+                    color={ki.pan}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-15Pan-${KIColor(ki.pan)}.png`}
+                    altText="Pan"
+                />
+                <KIComponent
+                    keyName="spoon"
+                    toggleKI={() => toggleKI('spoon')}
+                    color={ki.spoon}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-16Spoon-${KIColor(ki.spoon)}.png`}
+                    altText="Spoon"
+                />
+                <KIComponent
+                    keyName="rat"
+                    toggleKI={() => toggleKI('rat')}
+                    color={ki.rat}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-17RatTail-${KIColor(ki.rat)}.png`}
+                    altText="Rat Tail"
+                />
+                <KIComponent
+                    keyName="pink"
+                    toggleKI={() => toggleKI('pink')}
+                    color={ki.pink}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-18PinkTail-${KIColor(ki.pink)}.png`}
+                    altText="Pink Tail"
+                />
             </div>
             <p className='font-bold font-[family-name:var(--font-geist-mono)] text-sm'>{numOfKI} / {isV5 ? '18' : '17'}</p>
         </div>

--- a/src/app/ui/ki/ki-display.tsx
+++ b/src/app/ui/ki/ki-display.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { KeyItems } from "@/app/lib/interfaces";
 import KIComponent from './key-item';
 

--- a/src/app/ui/ki/ki-display.tsx
+++ b/src/app/ui/ki/ki-display.tsx
@@ -17,6 +17,7 @@ export default function KIDisplay({ ki, toggleKI, isV5 }: { ki: KeyItems, toggle
                     keyName="crystal"
                     toggleKI={() => toggleKI('crystal')}
                     color={ki.crystal}
+                    imgSrc={`/images/key-item-icons/FFIVFE-Icons-1THECrystal-${KIColor(ki.crystal)}.png`}
                 />
                 <a onClick={() => toggleKI('pass')}>
                     <Image 


### PR DESCRIPTION
KI display is now "tri-state", as it now has three toggles: Not obtained (grey), obtained (color) and cleared (color + check mark). This is to help players and viewers see whether or not a particular check has been done, especially in cases where the check tracker is hidden due to many objectives, something that is frequent in 5.0. This was done on a suggestion by c&c.

Also fixed a bug where introducing a new wyvern state (chaosburn) meant that an additional condition to check the absence of it needed to be added for standard wyvern.