### PR TITLE
5.0 alpha 2 support

### DIFF
--- a/src/app/lib/controls/objective-controle.ts
+++ b/src/app/lib/controls/objective-controle.ts
@@ -19,7 +19,6 @@ function beginv5ObjectiveEdit(id: number, group:number, setObjEdit: (id: number,
 
 function editObjective(id: number, title: string, objectives: TObjective[], setObjectives: (list: TObjective[]) => void, setObjEdit: Dispatch<SetStateAction<number>>, setMode: (mode: Mode) => void) {
     const target = objectives.find(obj => obj.id === id);
-    const targetIndex = objectives.findIndex(obj => obj.id === id);
     if (!!target) {
         const newList = objectives.filter(obj => obj.id !== id);
         const newObj:TObjective = {

--- a/src/app/lib/controls/objective-controle.ts
+++ b/src/app/lib/controls/objective-controle.ts
@@ -30,14 +30,22 @@ function editObjective(id: number, title: string, objectives: TObjective[], setO
         newList.sort((a, b) => a.id - b.id);
         setObjectives(newList);
         
-        if (target.id < objectives.length - 1) {
-            if (objectives[targetIndex + 1].random) {
-                setObjEdit((prevState: number) => prevState + 1);
-            } else {
-                setObjEdit(-1);
-                setMode(Mode.Info);
+        let hasReassignedEdit = false;
+
+        objectives.forEach((obj) => {
+            if (hasReassignedEdit) return;
+            if (obj.id <= target.id) return;
+            if (obj.random) {
+                hasReassignedEdit = true;
+                setObjEdit(obj.id);
             }
+        })
+
+        if (!hasReassignedEdit) {
+            setObjEdit(-1);
+            setMode(Mode.Info);
         }
+
     }
 }
 

--- a/src/app/lib/default-data.ts
+++ b/src/app/lib/default-data.ts
@@ -1390,7 +1390,26 @@ const questRewards: v5QuestReward[] = [
         slug: "dkmatter15",
         display: "Recieve 15 Dark Matter"
     },
-
+    {
+        slug: "item_t6_7",
+        display: "Recieve a Tier 6-7 item"
+    },
+    {
+        slug: "item_t6_8",
+        display: "Recieve a Tier 6-8 item"
+    },
+    {
+        slug: "item_t7",
+        display: "Recieve a Tier 7 item"
+    },
+    {
+        slug: "item_t7_8",
+        display: "Recieve a Tier 7-8 item"
+    },
+    {
+        slug: "item_t8",
+        display: "Recieve a Tier 8 item"
+    },
     
 
 ];

--- a/src/app/lib/default-data.ts
+++ b/src/app/lib/default-data.ts
@@ -421,6 +421,10 @@ const quests: Quest[] = [{
     title: 'Burn the village Mist with the Package',
     buttonText: 'Burn Mist',
 }, {
+    slug: 'kaipoinn',
+    title: 'Bring the Mist Village survivor to Kaipo',
+    buttonText: 'Kaipo Inn',
+}, {
     slug: 'curefever',
     title: 'Cure the fever with the SandRuby',
     buttonText: 'Turn in Sandruby',
@@ -1015,7 +1019,7 @@ const questsByKI: KIObjectives[] = [
     },
     {
         ki: 'package',
-        objectives: ['burnmist'],
+        objectives: ['burnmist', 'kaipoinn'],
         images: ['/images/key-item-icons/FFIVFE-Icons-7Package-Color.png']
     },
     {

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -528,6 +528,14 @@ const renderMisc = (flags: string) => {
             misc.push(<span key={`kicheckbonus${mult}`} className="flag-badge flag-badge-yay">+{mult}% XP per KI check</span>)
         }
     }
+    if (experienceString.indexOf('zonkbonus:') >= 0) {
+        if (experienceString.indexOf('zonkbonus:10') >= 0) {
+            misc.push(<span key="zonkbonus10" className="flag-badge flag-badge-yay">+10% XP per zonk</span>)
+        } else {
+            const mult = experienceString.charAt(experienceString.indexOf('zonkcheckbonus:') + 10);
+            misc.push(<span key={`zonkcheckbonus${mult}`} className="flag-badge flag-badge-yay">+{mult}% XP per KI zonk</span>)
+        }
+    }
     if (experienceString.indexOf('objbonus:3') >= 0) {
         misc.push(<span key="objbonus3" className="flag-badge flag-badge-yay">+3% XP per objective</span>)
     }

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -514,6 +514,20 @@ const renderMisc = (flags: string) => {
     if (experienceString.indexOf('objbonus:2') >= 0 && experienceString.indexOf('objbonus:20') < 0 && experienceString.indexOf('objbonus:25') < 0) {
         misc.push(<span key="objbonus2" className="flag-badge flag-badge-yay">+2% XP per objective</span>)
     }
+    if (experienceString.indexOf('bonuses:add') >= 0) {
+        misc.push(<span key="objbonusadd" className="flag-badge flag-badge-yay">Objective XP bonuses are additive</span>)
+    }
+    if (experienceString.indexOf('bonuses:mult') >= 0) {
+        misc.push(<span key="objbonusmult" className="flag-badge flag-badge-yay">Multiplicative XP bonuses</span>)
+    }
+    if (experienceString.indexOf('kicheckbonus:') >= 0) {
+        if (experienceString.indexOf('kicheckbonus:10') >= 0) {
+            misc.push(<span key="kicheckbonus10" className="flag-badge flag-badge-yay">+10% XP per KI check</span>)
+        } else {
+            const mult = experienceString.charAt(experienceString.indexOf('kicheckbonus:') + 13);
+            misc.push(<span key={`kicheckbonus${mult}`} className="flag-badge flag-badge-yay">+{mult}% XP per KI check</span>)
+        }
+    }
     if (experienceString.indexOf('objbonus:3') >= 0) {
         misc.push(<span key="objbonus3" className="flag-badge flag-badge-yay">+3% XP per objective</span>)
     }

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -170,18 +170,33 @@ const renderTreasure = (flags: string) => {
     // get character section of flag string
     const trString = getPropertySection(flags, 'T');
     
-    // check initial treasure settings
-    if (trString.indexOf('standard') >= 0) {
+    // check initial treasure settings - to discern regular trasure from miab settings, the general chest quality is always assumed to be first
+    if (trString.indexOf('Tstandard') >= 0) {
         TreasureText.push(<span key="standard" className="flag-badge"> Standard (Unweighted)</span>);
     }
-    if (trString.indexOf('pro') >= 0) {
+    if (trString.indexOf('Tpro') >= 0) {
         TreasureText.push(<span key="pro" className="flag-badge"> Pro (Weighted)</span>);
     }
-    if (trString.indexOf('wildish') >= 0) {
+    if (trString.indexOf('Twildish') >= 0) {
         TreasureText.push(<span key="wildish" className="flag-badge"> Wild-ish (Weighted)</span>)
     }
-    if (trString.indexOf('wild') >= 0 && trString.indexOf('wildish') < 0) {
+    if (trString.indexOf('Twild') >= 0 && trString.indexOf('wildish') < 0) {
         TreasureText.push(<span key="wild" className="flag-badge flag-badge-yay"> Wild (Unweighted)</span>);
+    }
+
+    // for miab adjustment, look for the whole miab string
+    // check initial treasure settings
+    if (trString.indexOf('miabs:standard') >= 0) {
+        TreasureText.push(<span key="miabsstandard" className="flag-badge"> Miabs:Standard (Unweighted)</span>);
+    }
+    if (trString.indexOf('miabs:pro') >= 0) {
+        TreasureText.push(<span key="miabspro" className="flag-badge"> Miabs:Pro (Weighted)</span>);
+    }
+    if (trString.indexOf('miabs:wildish') >= 0) {
+        TreasureText.push(<span key="miabswildish" className="flag-badge"> Miabs:Wild-ish (Weighted)</span>)
+    }
+    if (trString.indexOf('miabs:wild') >= 0 && trString.indexOf('wildish') < 0) {
+        TreasureText.push(<span key="miabswild" className="flag-badge flag-badge-yay"> Miabs:Wild (Unweighted)</span>);
     }
 
     // modifiers

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -85,8 +85,14 @@ const renderCharacters = (flags: string) => {
     if (charString.indexOf('noearned') >= 0) {
         characterText.push(<span key="no-earned" className="flag-badge flag-badge-danger"> No Earned Chars</span>)
     }
-    if (charString.indexOf('nopartner') >= 0) {
-        characterText.push(<span key="no-earned" className="flag-badge flag-badge-danger"> No Starting Partner</span>)
+    if (charString.indexOf('nopartner') >= 0 || charString.indexOf('partner:none') >= 0) {
+        characterText.push(<span key="partner-none" className="flag-badge flag-badge-danger"> No Starting Partner</span>)
+    }
+    if (charString.indexOf('partner:kicheck') >= 0) {
+        characterText.push(<span key="partner-ki" className="flag-badge"> Starting Partner is a KI check</span>)
+    }
+    if (charString.indexOf('partner:relaxed') >= 0) {
+        characterText.push(<span key="partner-relaxed" className="flag-badge flag-badge-yay"> Starting Partner relaxed</span>)
     }
     if (charString.indexOf('treasure') >= 0) {
         if (charString.indexOf('free') >= 0) {

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -532,7 +532,7 @@ const renderMisc = (flags: string) => {
         if (experienceString.indexOf('zonkbonus:10') >= 0) {
             misc.push(<span key="zonkbonus10" className="flag-badge flag-badge-yay">+10% XP per zonk</span>)
         } else {
-            const mult = experienceString.charAt(experienceString.indexOf('zonkcheckbonus:') + 10);
+            const mult = experienceString.charAt(experienceString.indexOf('zonkbonus:') + 10);
             misc.push(<span key={`zonkcheckbonus${mult}`} className="flag-badge flag-badge-yay">+{mult}% XP per KI zonk</span>)
         }
     }

--- a/src/app/lib/flag-badges-creator.tsx
+++ b/src/app/lib/flag-badges-creator.tsx
@@ -541,7 +541,7 @@ const renderMisc = (flags: string) => {
     if (experienceString.indexOf('objbonus:25') >= 0) {
         misc.push(<span key="objbonus25" className="flag-badge flag-badge-yay">+25% XP per objective</span>)
     }
-    if (flags.indexOf('spoon') >= 0) {
+    if (flags.indexOf('-spoon') >= 0) {
         misc.push(<span key="spoon" className="flag-badge flag-badge-yay">SPOON!</span>)
     }
     if (flags.indexOf('fastrom') >= 0) {

--- a/src/app/lib/helpers.ts
+++ b/src/app/lib/helpers.ts
@@ -1,0 +1,16 @@
+function getIndices(criteria:string, string:string):number[]  {
+    const len = criteria.length;
+    if (len === 0) {
+        return [];
+    }
+    let startIndex = 0;
+    let index = 0;
+    const result:number[] = [];
+    while ((index = string.indexOf(criteria, startIndex)) > -1) {
+        result.push(index);
+        startIndex = index + len;
+    }
+    return result;
+}
+
+export { getIndices }

--- a/src/app/lib/parse-flags.ts
+++ b/src/app/lib/parse-flags.ts
@@ -430,6 +430,8 @@ const parseFlags = (flagString: string):FlagObject => {
             flagObj.required = parseInt(flagString.charAt(flagString.indexOf('req:') + 4));
         } else if (flagString.indexOf('req:') >= 0 && flagString.indexOf('req:all') >= 0) {
             flagObj.required = flagString.indexOf('win:game') < 0 ? flagObj.objectives.length - 1 : flagObj.objectives.length;
+        } else if (flagString.indexOf('req:') < 0) {
+            flagObj.required = flagString.indexOf('win:game') < 0 ? flagObj.objectives.length - 1 : flagObj.objectives.length;
         }
 
     }

--- a/src/app/lib/parse-flags.ts
+++ b/src/app/lib/parse-flags.ts
@@ -2,6 +2,7 @@
 
 import { quests, bosses, questRewards } from '@/app/lib/default-data';
 import { FlagObject, v5Requirement } from '@/app/lib/interfaces';
+import { getIndices } from '@/app/lib/helpers';
 
 const parseFlags = (flagString: string):FlagObject => {
     if (!flagString || typeof flagString !== 'string') {
@@ -42,17 +43,22 @@ const parseFlags = (flagString: string):FlagObject => {
             // TODO: refactor objective checks so they aren't listed twice here
 
                 // check set objectives (non-custom)
-            if (setString.indexOf('collect_dkmatter') >= 0 ) {
-                const dkMatter = setString.indexOf('collect_dkmatter');
-                const digit1 = setString.charAt(dkMatter + 16);
-                const digit2 = setString.charAt(dkMatter + 17);
-                const isTwoDigit = isNaN(parseInt(digit2));
-                const dkMatterLabel = isTwoDigit ? digit1 : (digit1 + digit2);
-                setObj.push({
-                    id: setObj.length,
-                    label: `Turn in ${dkMatterLabel} Dark Matters to Kory`,
-                    time: 0,
-                });
+            const dkIndices = getIndices('collect_dkmatter', setString);
+            console.log('dk indices', dkIndices, setString)
+               
+            if (dkIndices.length ) {
+                dkIndices.forEach(dkMatter => {
+                    const digit1 = setString.charAt(dkMatter + 16);
+                    const digit2 = setString.charAt(dkMatter + 17);
+                    const isTwoDigit = isNaN(parseInt(digit2));
+                    const dkMatterLabel = isTwoDigit ? digit1 : (digit1 + digit2);
+                    setObj.push({
+                        id: setObj.length,
+                        label: `Turn in ${dkMatterLabel} Dark Matters to Kory`,
+                        time: 0,
+                    });
+                })
+                
             }
 
             if (setString.indexOf('classicforge') >= 0 ) {

--- a/src/app/lib/parse-flags.ts
+++ b/src/app/lib/parse-flags.ts
@@ -390,15 +390,6 @@ const parseFlags = (flagString: string):FlagObject => {
             }
         }
 
-        // don't forget the z-fight
-        if (flagString.indexOf('win:game') < 0) {
-            flagObj.objectives.push({
-                id: flagObj.objectives.length,
-                label: 'Defeat Zeromus',
-                time: 0,
-            })
-        }
-
         // random objectives
         const randomIndex = flagString.indexOf(`random:`);
         if (randomIndex >= 0) {
@@ -424,6 +415,16 @@ const parseFlags = (flagString: string):FlagObject => {
                 });
             }
         }
+
+                  // don't forget the z-fight
+        if (flagString.indexOf('win:game') < 0) {
+            flagObj.objectives.push({
+                id: flagObj.objectives.length,
+                label: 'Defeat Zeromus',
+                time: 0,
+            })
+        }
+
 
         // required objective number
         if (flagString.indexOf('req:') >= 0 && flagString.indexOf('req:all') < 0) {


### PR DESCRIPTION
Included support for alpha 2 features:

- Kaipo inn fight as an objective
- Random items in a set tier as an objective reward
- Flag badges for `Cpartner`, `Xbonus:`, `Xkicheckbonus:` and `Xzonkbonus`

Some bug fixes as well:

- Closes #16 - Spoon as an objective reward no longer false positives the `-spoon` flag
- Closes #17 - No requirement in an objective pool defaults to `do_all`.
- `Tmiab:` settings no longer trigger the general treasure setting. Worth nothing that the "fix" for this assumes that the general setting will ALWAYS be first, i.e. `Tpro/....` (reported by C&C)
- "Beat Zeromus" objective in 4.6 now should always be last. (also reported by C&C)
- Multiple `collect_dkmatter` objectives in one set is now supported. 